### PR TITLE
Fix undefined data in firestore set operation

### DIFF
--- a/admin/admin.html
+++ b/admin/admin.html
@@ -17,11 +17,6 @@
       type="image/svg+xml"
       href="../assets/icons/favicon-admin.svg"
     />
-    <link
-      rel="icon"
-      type="image/png"
-      href="../assets/icons/favicon-admin.png"
-    />
     <!-- Firebase SDK -->
     <script src="https://www.gstatic.com/firebasejs/9.22.0/firebase-app-compat.js"></script>
     <script src="https://www.gstatic.com/firebasejs/9.22.0/firebase-auth-compat.js"></script>

--- a/js/admin.js
+++ b/js/admin.js
@@ -441,7 +441,7 @@
       time: time,
       description: description,
       details: details,
-      room: room || undefined,
+      room: room || '',
       urgent: urgent,
       updatedAt: firebase && firebase.firestore ? firebase.firestore.FieldValue.serverTimestamp() : Date.now(),
     };
@@ -505,7 +505,7 @@
     var payload = {
       code: code,
       title: title,
-      instructor: instructor || undefined,
+      instructor: instructor || '',
       description: '',
       updatedAt: firebase && firebase.firestore ? firebase.firestore.FieldValue.serverTimestamp() : Date.now(),
     };
@@ -570,7 +570,7 @@
       courseId: courseId,
       type: type,
       title: title,
-      description: description || undefined,
+      description: description || '',
       url: url,
       linkUrl: url,
       section: section,
@@ -752,9 +752,9 @@
       date: normalizeDateValue(qs('#extraClassDate').value),
       day: qs('#extraClassDay').value || '',
       time: qs('#extraClassTime').value || '',
-      room: (qs('#extraClassRoom').value || '').trim() || undefined,
-      instructor: (qs('#extraClassInstructor').value || '').trim() || undefined,
-      description: (qs('#extraClassDescription').value || '').trim() || undefined,
+      room: (qs('#extraClassRoom').value || '').trim() || '',
+      instructor: (qs('#extraClassInstructor').value || '').trim() || '',
+      description: (qs('#extraClassDescription').value || '').trim() || '',
       updatedAt: firebase && firebase.firestore ? firebase.firestore.FieldValue.serverTimestamp() : Date.now(),
     };
     if (!editing.extraClassId) payload.createdAt = payload.updatedAt;


### PR DESCRIPTION
Fixes Firebase errors by replacing `undefined` with empty strings for optional fields and removes a missing favicon link.

Firebase rejects document writes when fields are explicitly `undefined`, so empty strings are used instead to ensure successful data saving for resources, events, and courses.

---
<a href="https://cursor.com/background-agent?bcId=bc-62855194-9db7-4c63-b5fe-63bdf9327c05">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-62855194-9db7-4c63-b5fe-63bdf9327c05">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

