### PR TITLE
Fix javascript syntax error

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -3319,7 +3319,7 @@ membersContainer.addEventListener('click', (e) => {
 
     if (profileForm) profileForm.addEventListener('submit', saveProfile);
 
-    async function signInWithGoogleCuetOnly() {
+    (async function signInWithGoogleCuetOnly() {
         const maxRetries = 3;
         let retryCount = 0;
         
@@ -3617,3 +3617,4 @@ document.addEventListener('DOMContentLoaded', () => {
         try { subscribeToPublicProfilesUpdates(); } catch (_) {}
     }).catch(() => {});
 });
+})();


### PR DESCRIPTION
Wrap `signInWithGoogleCuetOnly` in an IIFE to fix a JavaScript syntax error.

---
<a href="https://cursor.com/background-agent?bcId=bc-622705de-28b4-47ba-975c-fe74100e1c49">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-622705de-28b4-47ba-975c-fe74100e1c49">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

