### PR TITLE
Fix profile window scrollbar theme mismatch

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2135,6 +2135,33 @@ body {
   scrollbar-color: rgba(0, 212, 255, 0.6) rgba(25, 15, 50, 0.8);
 }
 
+/* Profile Modal Scrollbar Styling */
+#profile-card::-webkit-scrollbar {
+  width: 8px;
+}
+
+#profile-card::-webkit-scrollbar-track {
+  background: rgba(250, 21, 136, 0.1);
+  border-radius: 4px;
+}
+
+#profile-card::-webkit-scrollbar-thumb {
+  background: linear-gradient(135deg, rgb(250, 21, 136), #ff6b9d);
+  border-radius: 4px;
+  border: 1px solid rgba(250, 21, 136, 0.3);
+}
+
+#profile-card::-webkit-scrollbar-thumb:hover {
+  background: linear-gradient(135deg, #ff6b9d, rgb(250, 21, 136));
+  box-shadow: 0 0 10px rgba(250, 21, 136, 0.5);
+}
+
+/* Firefox scrollbar styling for profile modal */
+#profile-card {
+  scrollbar-width: thin;
+  scrollbar-color: rgb(250, 21, 136) rgba(250, 21, 136, 0.1);
+}
+
 .routine-table table {
   width: 100%;
   min-width: 1000px;
@@ -2435,3 +2462,5 @@ body {
   font-size: 14px;
   letter-spacing: 0.2px;
 }
+
+


### PR DESCRIPTION
Adds custom scrollbar styling to the profile window to match the application's theme.

---
<a href="https://cursor.com/background-agent?bcId=bc-1bf011da-173c-4b56-8344-7e7bfef13b67">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1bf011da-173c-4b56-8344-7e7bfef13b67">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

