### PR TITLE
Fix login page redirect bug

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -3013,12 +3013,8 @@ membersContainer.addEventListener('click', (e) => {
         showView(initialView);
         overlay.style.display = 'flex';
         setTimeout(() => overlay.classList.add('show'), 10);
-        if (activeModal === null && window.history && window.history.pushState) {
-            window.history.pushState({ modal: 'student-auth' }, "");
-            activeModal = 'student-auth';
-        } else {
-            activeModal = 'student-auth';
-        }
+        // Removed history.pushState for student-auth to avoid unintended back navigation
+        activeModal = 'student-auth';
         preventMainPageScroll();
     }
 
@@ -3030,10 +3026,7 @@ membersContainer.addEventListener('click', (e) => {
     }
 
     function closeStudentAuthModal() {
-        if (window.history && window.history.state && window.history.state.modal === 'student-auth') {
-            window.history.back();
-            return;
-        }
+        // Close directly without history.back for student-auth
         actuallyCloseStudentAuthModal();
     }
 
@@ -3042,7 +3035,7 @@ membersContainer.addEventListener('click', (e) => {
 
     window.addEventListener('popstate', () => {
         if (activeModal === 'student-auth') {
-            actuallyCloseStudentAuthModal();
+            // No-op for student-auth: do not auto-close due to history changes
             return;
         }
         if (activeModal === 'profile') {
@@ -3052,8 +3045,9 @@ membersContainer.addEventListener('click', (e) => {
     });
 
     document.addEventListener('keydown', (e) => {
-        if (e.key === 'Escape' && activeModal === 'student-auth' && window.history && window.history.state?.modal === 'student-auth') {
-            window.history.back();
+        if (e.key === 'Escape' && activeModal === 'student-auth') {
+            // Close directly without relying on history.state
+            actuallyCloseStudentAuthModal();
         }
         if (e.key === 'Escape' && activeModal === 'profile' && window.history && window.history.state?.modal === 'profile') {
             window.history.back();


### PR DESCRIPTION
Remove history manipulation from student login modal to prevent automatic backward navigation during login.

The student login modal was incorrectly using `history.pushState` and `history.back` which caused the page to navigate backward when attempting to log in, preventing successful authentication. This change ensures the modal closes directly without affecting browser history.

---
<a href="https://cursor.com/background-agent?bcId=bc-40a85735-6c21-4e16-b315-e571516ac2f7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-40a85735-6c21-4e16-b315-e571516ac2f7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

