### PR TITLE
Fix login redirect loop

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -3314,7 +3314,7 @@ membersContainer.addEventListener('click', (e) => {
 
     if (profileForm) profileForm.addEventListener('submit', saveProfile);
 
-    (async function signInWithGoogleCuetOnly() {
+    async function signInWithGoogleCuetOnly() {
         const maxRetries = 3;
         let retryCount = 0;
         


### PR DESCRIPTION
Fixes Google login redirect loop by making the sign-in function user-initiated.

The Google sign-in function was self-invoking on page load, causing an infinite redirect loop after successful authentication. This change ensures it only runs when triggered by user interaction.

---
<a href="https://cursor.com/background-agent?bcId=bc-ba1ec28e-4dfc-4563-be15-c16404090c4f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ba1ec28e-4dfc-4563-be15-c16404090c4f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

